### PR TITLE
Heroku initial deploy

### DIFF
--- a/app/mailers/registration_mailer.rb
+++ b/app/mailers/registration_mailer.rb
@@ -1,5 +1,5 @@
 class RegistrationMailer < ApplicationMailer
-  default from: 'admin@battleshift.com'
+  default from: 'app92045074@heroku.com'
 
   def activate(user)
     @user = user

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -72,7 +72,7 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "battleship_web_#{Rails.env}"
   config.action_mailer.perform_caching = false
 
-  # config.action_mailer.default_url_options = { host: ''}
+  config.action_mailer.default_url_options = { host: 'https://lit-hollows-27475.herokuapp.com'}
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.


### PR DESCRIPTION
+ change default from to send grid username in action mailer
+ set default url for action mailer in production env